### PR TITLE
Fix compile error

### DIFF
--- a/UnblockNeteaseMusic/Makefile
+++ b/UnblockNeteaseMusic/Makefile
@@ -17,10 +17,10 @@ PKG_USE_MIPS16:=0
 GO_PKG:=github.com/cnsilvan/UnblockNeteaseMusic
 GO_PKG_LDFLAGS:=-s -w
 # +%Y-%m-%d %H:%M:%S cause compile error 
-COMPILE_TIME := $(shell TZ=UTC-8 date '+%Y-%m-%d/%H:%M:%S')
-GO_PKG_LDFLAGS_X:= \
-	$(GO_PKG)/version.Version=$(PKG_VERSION) \
-    $(GO_PKG)/version.BuildTime="$(COMPILE_TIME)" 
+COMPILE_TIME := $(shell TZ=UTC-8 date '+%Y-%m-%d %H:%M:%S')
+GO_PKG_LDFLAGS+= \
+	-X '$(GO_PKG)/version.Version=$(PKG_VERSION)' \
+	-X '$(GO_PKG)/version.BuildTime=$(COMPILE_TIME)' 
 include $(INCLUDE_DIR)/package.mk
 include $(TOPDIR)/feeds/packages/lang/golang/golang-package.mk
 
@@ -46,7 +46,7 @@ endef
 define Build/Compile
 	$(eval GO_PKG_BUILD_PKG:=$(GO_PKG))
 	$(call GoPackage/Build/Configure)
-	$(eval GO_PKG_LDFLAGS_X+=$(GO_PKG)/version.ExGoVersionInfo="$(GO_ARM) $(GO_MIPS)$(GO_MIPS64)")
+	$(eval GO_PKG_LDFLAGS+=-X '$(GO_PKG)/version.ExGoVersionInfo=$(GO_ARM) $(GO_MIPS)$(GO_MIPS64)')
 	$(call GoPackage/Build/Compile)
 	$(STAGING_DIR_HOST)/bin/upx --lzma --best $(GO_PKG_BUILD_BIN_DIR)/UnblockNeteaseMusic
 	chmod +wx $(GO_PKG_BUILD_BIN_DIR)/UnblockNeteaseMusic


### PR DESCRIPTION
Can't use `GO_PKG_LDFLAGS_X` to define X args with space, use `GO_PKG_LDFLAGS -X` instead to fix compile error.