### PR TITLE
fix depends

### DIFF
--- a/luci-app-unblockneteasemusic/Makefile
+++ b/luci-app-unblockneteasemusic/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI support for UnblockNeteaseMusic
-LUCI_DEPENDS:= +bash +busybox +coreutils-nohup +curl +dnsmasq-full +ipset +UnblockNeteaseMusic
+LUCI_DEPENDS:= +bash +busybox +coreutils +coreutils-nohup +curl +dnsmasq-full +ipset +luci-compat +openssl-util +UnblockNeteaseMusic
 LUCI_PKGARCH:=all
 PKG_NAME:=luci-app-unblockneteasemusic
 PKG_VERSION:=1.7


### PR DESCRIPTION
您好，首先感谢您开发的这个golang版本的unblockneteasemusic插件，我这两天编译这个插件到原版openwrt有些问题如下：
1、make menuconfig列表找不到这个luci插件，后发现是默认情况无法满足coreutils-nohup这个依赖，如果不先选中coreutils就没有含coreutils-nohup的下级菜单，故加上coreutils依赖
2、编译完成后仍旧需要luci-compat插件，否则会缺luci.cbi模块
3、启动插件时需要openssl可执行文件，需安装openssl-util
以上为个人编译原版openwrt时遇到问题解决方式，不一定正确，请斟酌采纳
另外在编译中还出现过dnsmasq和dnsmasq-full的冲突问题（问题见附件），即选中这个插件的话必须记得手动取消dnsmasq，不知到有没有好的解决办法，望告知
![截图_2020-03-15_18-34-05](https://user-images.githubusercontent.com/34626506/76699877-88b37a00-66ec-11ea-85ca-3a10746e1214.png)
