### PR TITLE
修改V4网络连通性检查方式&添加IPv6地址查询的完整性

### DIFF
--- a/luci-app-unblockneteasemusic/root/etc/init.d/unblockneteasemusic
+++ b/luci-app-unblockneteasemusic/root/etc/init.d/unblockneteasemusic
@@ -58,11 +58,13 @@ set_ipset() {
 			if ! ipset list unblockneteasemusic6 >"/dev/null"; then ipset create unblockneteasemusic6 hash:ip family inet6; fi
 			domains="music.163.com"
 			for domain in $domains; do
-				ip=$(ping6 ${domain} -c 1 | sed '1{s/[^(]*(//;s/).*//;q}')
-				if [ -n "$ip" ]; then 
-				 ipset add unblockneteasemusic6 $ip
+				ip=$(nslookup music.163.com | grep "Address " | grep -v "\." | awk '{print $3}')
+				if [ -n "$ip" ]; then
+					for addr in $ip; do
+						ipset add unblockneteasemusic6 $addr
+					done
 				else
-				 echo "ping6 bad address,please check IPv6 DNS forwards.if IPv6 DNS forwards is enabled, please restart" >>"${logFile}"
+					echo "Query bad address,please check IPv6 DNS forwards.if IPv6 DNS forwards is enabled, please restart" >>"${logFile}"
 				fi
 			done
 			ipset add unblockneteasemusic unblockneteasemusic6
@@ -138,7 +140,7 @@ subjectAltName=DNS:music.163.com,DNS:*.music.163.com" >"${extFile}"
 start() {
 	stop >>"${logFile}" 2>&1
 	[ "${enable}" -ne "1" ] && exit 0
-	ping -c 1 114.114.114.114 >/dev/null 2>&1
+	curl www.baidu.com >/dev/null 2>&1
 	if [ $? -eq 0 ]; then
 		if [ ! -f "$serverCrt" ]; then
 			createCertificate >>"${logFile}" 2>&1


### PR DESCRIPTION
1. IPv4在某些运营商或环境下会禁ping,使用curl来替代
2. music.163.com可能存在多个IPv6地址,通过抓包检查客户端会出现切换地址的情况,因此改为使用nslookup查询所有地址并把所有IPv6地址添加进IPset